### PR TITLE
Fixed database passwords on the VMSS template

### DIFF
--- a/AzSQLFrontendVMSS.json
+++ b/AzSQLFrontendVMSS.json
@@ -275,16 +275,16 @@
                         "value": "[parameters('databaseAdministratorPass')]"
                     },
                     "OSDBSessionPass": {
-                        "value": "[parameters('adminPassword')]"
+                        "value": "[parameters('databaseAdministratorPass')]"
                     },
                     "OSDBAdminPass": {
-                        "value": "[parameters('adminPassword')]"
+                        "value": "[parameters('databaseAdministratorPass')]"
                     },
                     "OSDBRuntimePass": {
-                        "value": "[parameters('adminPassword')]"
+                        "value": "[parameters('databaseAdministratorPass')]"
                     },
                     "OSDBLogPass": {
-                        "value": "[parameters('adminPassword')]"
+                        "value": "[parameters('databaseAdministratorPass')]"
                     },
                     "OSController": {
                         "value": "[reference(concat('Microsoft.Resources/deployments/OutSystems.DC.', concat(parameters('virtualMachineName')))).outputs.virtualMachineName.value]"


### PR DESCRIPTION
- The VMSS template was using the VM password for the platform DB users instead of the DB Admin password. Was causing the template to fail if the VM password was different than the SQL Admin password.